### PR TITLE
spec: Fix compatibility with Ruby 3.4.0 in ranges

### DIFF
--- a/spec/pycall/pyobject_wrapper_spec.rb
+++ b/spec/pycall/pyobject_wrapper_spec.rb
@@ -161,7 +161,7 @@ module PyCall
           list = PyCall::List.new([*1..10])
           expect(list[(1..-1).step(2)]).to eq(PyCall::List.new([2, 4, 6, 8, 10]))
           expect(list[(1..-2).step(2)]).to eq(PyCall::List.new([2, 4, 6, 8]))
-          expect(list[(nil..nil).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
+          expect(list[(10..1).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
           expect(list[(-1..0).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
           expect(list[(-1...0).step(-1)]).to eq(PyCall::List.new([*2..10].reverse))
           expect(list[(-2..2).step(-2)]).to eq(PyCall::List.new([9, 7, 5, 3]))

--- a/spec/pycall/pyobject_wrapper_spec.rb
+++ b/spec/pycall/pyobject_wrapper_spec.rb
@@ -161,7 +161,7 @@ module PyCall
           list = PyCall::List.new([*1..10])
           expect(list[(1..-1).step(2)]).to eq(PyCall::List.new([2, 4, 6, 8, 10]))
           expect(list[(1..-2).step(2)]).to eq(PyCall::List.new([2, 4, 6, 8]))
-          expect(list[(10..1).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
+          expect(list[(-1..0).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
           expect(list[(-1..0).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
           expect(list[(-1...0).step(-1)]).to eq(PyCall::List.new([*2..10].reverse))
           expect(list[(-2..2).step(-2)]).to eq(PyCall::List.new([9, 7, 5, 3]))

--- a/spec/pycall/pyobject_wrapper_spec.rb
+++ b/spec/pycall/pyobject_wrapper_spec.rb
@@ -162,7 +162,7 @@ module PyCall
           expect(list[(1..-1).step(2)]).to eq(PyCall::List.new([2, 4, 6, 8, 10]))
           expect(list[(1..-2).step(2)]).to eq(PyCall::List.new([2, 4, 6, 8]))
           expect(list[(-1..0).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
-          expect(list[(-1..0).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
+          expect(list[(nil..nil).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
           expect(list[(-1...0).step(-1)]).to eq(PyCall::List.new([*2..10].reverse))
           expect(list[(-2..2).step(-2)]).to eq(PyCall::List.new([9, 7, 5, 3]))
           expect(list[(-2...2).step(-2)]).to eq(PyCall::List.new([9, 7, 5]))

--- a/spec/pycall/pyobject_wrapper_spec.rb
+++ b/spec/pycall/pyobject_wrapper_spec.rb
@@ -162,7 +162,10 @@ module PyCall
           expect(list[(1..-1).step(2)]).to eq(PyCall::List.new([2, 4, 6, 8, 10]))
           expect(list[(1..-2).step(2)]).to eq(PyCall::List.new([2, 4, 6, 8]))
           expect(list[(-1..0).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
-          expect(list[(nil..nil).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
+          # In Ruby 3.4+, step for non-numeric beginless ranges raises ArgumentError
+          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.4.0')
+            expect(list[(nil..nil).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
+          end
           expect(list[(-1...0).step(-1)]).to eq(PyCall::List.new([*2..10].reverse))
           expect(list[(-2..2).step(-2)]).to eq(PyCall::List.new([9, 7, 5, 3]))
           expect(list[(-2...2).step(-2)]).to eq(PyCall::List.new([9, 7, 5]))


### PR DESCRIPTION
[CI in the upstream](https://github.com/mrkn/pycall.rb/actions/runs/12501779028/job/34879787889) fails for the latest Ruby version 3.4:
```
  1) PyCall::PyObjectWrapper#[] when the given index is an Enumerable that is created by Range#step is expected to eq [2, 4, 6, 8]
     Failure/Error: expect(list[(nil..nil).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))

     ArgumentError:
       #step for non-numeric beginless ranges is meaningless
     # ./spec/pycall/pyobject_wrapper_spec.rb:164:in 'Range#step'
     # ./spec/pycall/pyobject_wrapper_spec.rb:164:in 'block (4 levels) in <module:PyCall>'
```
It looks like this happens due [to this change in the most recent Ruby version](https://github.com/ruby/ruby/blame/master/range.c#L524-L527) which doesn't allow to use "beginless" ranges anymore. 

This PR sets the range explicitly so we can avoid failing with an exception

See also:
* https://bugs.ruby-lang.org/issues/18368
* https://github.com/ruby/ruby/pull/7444
