### PR TITLE
Fix step behavior for beginless ranges in Ruby 3.4+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
         - { os: ubuntu-22.04   , ruby: 2.7   , python: "3.9"  , python_architecture: x64 , venv: "" }
         - { os: ubuntu-22.04   , ruby: 2.7   , python: "3.8"  , python_architecture: x64 , venv: "" }
         - { os: ubuntu-22.04   , ruby: 2.7   , python: "3.7"  , python_architecture: x64 , venv: "" }
-        - { os: ubuntu-22.04   , ruby: 2.7   , python: "3.6"  , python_architecture: x64 , venv: "" }
 
         # Ruby-debug with the latest Python 3
         - { os: ubuntu-22.04   , ruby: debug , python: "3.x"  , python_architecture: x64 , venv: "" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        - ubuntu-20.04
+        - ubuntu-22.04
         - macos-latest
         ruby:
         - "3.4"
@@ -39,27 +39,27 @@ jobs:
         - ""
         include:
         # Python 3.11 with the latest Ruby
-        - { os: ubuntu-20.04   , ruby: 3.3   , python: "3.11" , python_architecture: x64 , venv: "" }
+        - { os: ubuntu-22.04   , ruby: 3.3   , python: "3.11" , python_architecture: x64 , venv: "" }
 
         # Old ruby and the latest Python 3
-        - { os: ubuntu-20.04   , ruby: 2.6   , python: "3.x"  , python_architecture: x64 , venv: "" }
-        - { os: ubuntu-20.04   , ruby: 2.5   , python: "3.x"  , python_architecture: x64 , venv: "" }
-        - { os: ubuntu-20.04   , ruby: 2.4   , python: "3.x"  , python_architecture: x64 , venv: "" }
+        - { os: ubuntu-22.04   , ruby: 2.6   , python: "3.x"  , python_architecture: x64 , venv: "" }
+        - { os: ubuntu-22.04   , ruby: 2.5   , python: "3.x"  , python_architecture: x64 , venv: "" }
+        - { os: ubuntu-22.04   , ruby: 2.4   , python: "3.x"  , python_architecture: x64 , venv: "" }
 
         # Ruby 2.7 with Each Python 3.x
-        - { os: ubuntu-20.04   , ruby: 2.7   , python: "3.12" , python_architecture: x64 , venv: "" }
-        - { os: ubuntu-20.04   , ruby: 2.7   , python: "3.11" , python_architecture: x64 , venv: "" }
-        - { os: ubuntu-20.04   , ruby: 2.7   , python: "3.10" , python_architecture: x64 , venv: "" }
-        - { os: ubuntu-20.04   , ruby: 2.7   , python: "3.9"  , python_architecture: x64 , venv: "" }
-        - { os: ubuntu-20.04   , ruby: 2.7   , python: "3.8"  , python_architecture: x64 , venv: "" }
-        - { os: ubuntu-20.04   , ruby: 2.7   , python: "3.7"  , python_architecture: x64 , venv: "" }
-        - { os: ubuntu-20.04   , ruby: 2.7   , python: "3.6"  , python_architecture: x64 , venv: "" }
+        - { os: ubuntu-22.04   , ruby: 2.7   , python: "3.12" , python_architecture: x64 , venv: "" }
+        - { os: ubuntu-22.04   , ruby: 2.7   , python: "3.11" , python_architecture: x64 , venv: "" }
+        - { os: ubuntu-22.04   , ruby: 2.7   , python: "3.10" , python_architecture: x64 , venv: "" }
+        - { os: ubuntu-22.04   , ruby: 2.7   , python: "3.9"  , python_architecture: x64 , venv: "" }
+        - { os: ubuntu-22.04   , ruby: 2.7   , python: "3.8"  , python_architecture: x64 , venv: "" }
+        - { os: ubuntu-22.04   , ruby: 2.7   , python: "3.7"  , python_architecture: x64 , venv: "" }
+        - { os: ubuntu-22.04   , ruby: 2.7   , python: "3.6"  , python_architecture: x64 , venv: "" }
 
         # Ruby-debug with the latest Python 3
-        - { os: ubuntu-20.04   , ruby: debug , python: "3.x"  , python_architecture: x64 , venv: "" }
+        - { os: ubuntu-22.04   , ruby: debug , python: "3.x"  , python_architecture: x64 , venv: "" }
 
         # The latest stable Ruby with the latest Python 3 with venv
-        - { os: ubuntu-20.04   , ruby: "3.3" , python: "3.x"  , python_architecture: x64 , venv: "venv:"  }
+        - { os: ubuntu-22.04   , ruby: "3.3" , python: "3.x"  , python_architecture: x64 , venv: "venv:"  }
 
         # macOS with venv
         - { os: macos-latest   , ruby: "3.3" , python: "3.x"  , python_architecture: x64 , venv: "venv:"  }
@@ -110,7 +110,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu-20.04
+        - ubuntu-22.04
         #- macos-latest
         ruby:
         - "3.1"

--- a/spec/pycall/pyobject_wrapper_spec.rb
+++ b/spec/pycall/pyobject_wrapper_spec.rb
@@ -161,10 +161,7 @@ module PyCall
           list = PyCall::List.new([*1..10])
           expect(list[(1..-1).step(2)]).to eq(PyCall::List.new([2, 4, 6, 8, 10]))
           expect(list[(1..-2).step(2)]).to eq(PyCall::List.new([2, 4, 6, 8]))
-          # In Ruby 3.4+, step for non-numeric beginless ranges raises ArgumentError
-          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.4.0')
-            expect(list[(nil..nil).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
-          end
+          expect(list[(nil..nil).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
           expect(list[(-1..0).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
           expect(list[(-1...0).step(-1)]).to eq(PyCall::List.new([*2..10].reverse))
           expect(list[(-2..2).step(-2)]).to eq(PyCall::List.new([9, 7, 5, 3]))

--- a/spec/pycall/pyobject_wrapper_spec.rb
+++ b/spec/pycall/pyobject_wrapper_spec.rb
@@ -161,7 +161,10 @@ module PyCall
           list = PyCall::List.new([*1..10])
           expect(list[(1..-1).step(2)]).to eq(PyCall::List.new([2, 4, 6, 8, 10]))
           expect(list[(1..-2).step(2)]).to eq(PyCall::List.new([2, 4, 6, 8]))
-          expect(list[(nil..nil).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
+          # In Ruby 3.4+, step for non-numeric beginless ranges raises ArgumentError
+          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.4.0')
+            expect(list[(nil..nil).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
+          end
           expect(list[(-1..0).step(-1)]).to eq(PyCall::List.new([*1..10].reverse))
           expect(list[(-1...0).step(-1)]).to eq(PyCall::List.new([*2..10].reverse))
           expect(list[(-2..2).step(-2)]).to eq(PyCall::List.new([9, 7, 5, 3]))


### PR DESCRIPTION
This pull request will allow the test to pass in Ruby 3.4.
Currently [the test fails](https://github.com/red-data-tools/pycall.rb/actions/runs/13205512239/job/36867654621
) on Ruby 3.4.

```
irb(main):001> (nil..nil).step(-1)
(irb):1:in 'Range#step': #step for non-numeric beginless ranges is meaningless (ArgumentError)
````

See https://github.com/ruby/ruby/pull/7444