### PR TITLE
ci: accept more push branches for easy to check on fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,8 @@ name: CI
 on:
   push:
     branches:
-    - master
-    - "check/ci/**"
-    - "check/unix/**"
+    - "**"
+    - '!dependabot/**'
   pull_request:
     types:
     - opened

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,9 +3,8 @@ name: Windows
 on:
   push:
     branches:
-    - master
-    - "check/ci/**"
-    - "check/windows/**"
+    - "**"
+    - '!dependabot/**'
   pull_request:
     types:
     - opened


### PR DESCRIPTION
We can use any branch name to check CI on fork.