### PR TITLE
ci: remove needless `pull_request.types`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,6 @@ on:
     - "check/ci/**"
     - "check/unix/**"
   pull_request:
-    types:
-    - opened
-    - synchronize
-    - reopened
 
 jobs:
   test:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,10 +7,6 @@ on:
     - "check/ci/**"
     - "check/windows/**"
   pull_request:
-    types:
-    - opened
-    - synchronize
-    - reopened
 
 jobs:
   test:


### PR DESCRIPTION
The specified types are default.